### PR TITLE
Fixed context loss on daughter task creation

### DIFF
--- a/program_tasks.md
+++ b/program_tasks.md
@@ -9,6 +9,7 @@
 
 
 ## Bugs
+- [] Notes being copied to context are not adding to the entire history (see 27/06/22 for eg)
 - [x] Asking for extra time and restarting again does not remember the amount of time passed in the previous iteration.
 - [x] duplicating is not making a replica, rather it is moving the same event to the next day
 - [x] Add ability to explore task, just do a task and add details later
@@ -18,10 +19,17 @@
 - [] Add ability to distribute an event over many days. Eg do twitter writeup 30 mins/day 3 times over 5 days.
 - [] Show in the view how many lines of context and/or notes the activity has
 - [] Capture streak of the activity
-- [] when I add a task, show me number of hours accounted for in the day
-- [] dual thread so that timer stays running and I can take notes
-- [] keep track of number of hours scheduled (so i dont overbook my day)
+- [] When I add a task, show me number of hours accounted for in the day
+- [] Dual thread so that timer stays running and I can take notes
+- [] Keep track of number of hours scheduled (so i dont overbook my day)
+- [] Rechedule takes current day into account. This becomes confusing. Do reschedule based on the date in the db
+- [] Subtask timers i.e show the current subtask and add a timer for that
+- [] show how long activity has been paused (used explore track to keep track of that)
+- [] Add grouping for tasks so you can drill into a category and finish those first (eg: big tasks, small tasks, break tasks. revenue tasks, etc)
 
+## UI improvements
+- [] Show date when you have begun your day since now you can start a previous day
+- 
 
 ## Complex features
 - [] Capture sub tasks while doing main task (start timer for them)

--- a/src/activity/activity.py
+++ b/src/activity/activity.py
@@ -101,11 +101,23 @@ class Activity:
         daughter_details = SqlActivityDetailsQueryFactory(parent_activity_id = daughter_id)
         
         # the user can only add notes, the notes are copied into the context of the daughter
+        # you have to check if context exists if it does include that too
+        # create a separate function to combine both context and note
         daughter_details.initialize_daughter_details(
-            context= self.query_details.get_notes()
+            context= self.concatenate_context_and_note()
         )
         
 
+    def concatenate_context_and_note(self):
+        concatenated_string = ""
+        for row in self.query_details.show_details():
+            context, notes = row 
+        if context:
+            concatenated_string = f"{concatenated_string}{context}"
+        if notes:
+            concatenated_string = f"{concatenated_string}\n{notes}"
+        
+        return concatenated_string
 
     def show_feedback(self):
         keys = ["#Activities", "Total time", "Average time"]

--- a/src/query_factory.py
+++ b/src/query_factory.py
@@ -160,12 +160,12 @@ class SqlActivityDetailsQueryFactory:
 
     def get_notes(self):
         q = f"""
-        SELECT notes FROM activity_details 
+        SELECT context, notes FROM activity_details 
         WHERE activity_id = {self.id}
         """
         for row in self.sql.execute_single_read_query(q):
             notes = row
-        return notes
+        return notes 
 
 
 class SqlGeneralQueryFactory:


### PR DESCRIPTION
# Bugs fixed
- Due to a poor implementation of the daughter task creation, the context of the parent was being lost and only notes of the parent were being persisted. 
- Fixed this by concatenating the notes and the context. There might be extra line breaks being added that I will fix later but the chains persist which is most important. 